### PR TITLE
Early return doesn't allow use of multiple OPorts

### DIFF
--- a/Domain/Generator/Generator.py
+++ b/Domain/Generator/Generator.py
@@ -70,7 +70,7 @@ class Generator(DomainBehavior):
 				msg = Message(data, self.timeNext)
 				i = self.__listValues.index(item)
 
-				return self.poke(self.OPorts[i], msg)
+				self.poke(self.OPorts[i], msg)
 		else:
 			data = [self.V[0].pop(0), 0.0, 0.0]
 			msg = Message(data, self.timeNext)


### PR DESCRIPTION
If using multiple OPorts, removing the return allows all OPorts to be loaded with output messages.